### PR TITLE
README: fix DAMON project site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ HMSDK consists of multiple git submodules so please download it as follows.
 - 2024-04-19: numactl supports [--weighted-interleave](https://github.com/numactl/numactl/commit/b67fb88e77b3c200b0e300e2e0edc4f66c1d9ea5) option
 - 2024-02-22: HMSDK v1.1 kernel patches have landed into upstream Linux kernel (available from v6.9)
   - [MPOL_WEIGHTED_INTERLEAVE](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=fa3bea4e1f8202d787709b7e3654eb0a99aed758) memory policy and its [sysfs interface](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dce41f5ae2539d1c20ae8de4e039630aec3c3f3c) (co-developed by [MemVerge](http://www.memverge.com))
-- 2023-12-27: HMSDK v2.0 released - support [DAMON](https://sjp38.github.io/post/damon) based 2-tier memory management
+- 2023-12-27: HMSDK v2.0 released - support [DAMON](https://damonitor.github.io) based 2-tier memory management
 - 2023-05-09: HMSDK v1.1 released - support bandwidth aware interleaving, user library and tools
 
 ## License


### PR DESCRIPTION
The project site has moved to https://damonitor.github.io, and the old URL is no more working.  Update the link.